### PR TITLE
Use gpio:start_link/1 in examples (gpio_counter).

### DIFF
--- a/examples/gpio_counter.erl
+++ b/examples/gpio_counter.erl
@@ -41,12 +41,12 @@ start_link() ->
 %%%===================================================================
 
 init([]) ->
-    {ok, _} = gpio:start_link(?UP_PIN, input),
-    {ok, _} = gpio:start_link(?DOWN_PIN, input),
+    {ok, _} = gpio:start_link({?UP_PIN, input}),
+    {ok, _} = gpio:start_link({?DOWN_PIN, input}),
     ok = gpio:set_int(?UP_PIN, rising),
     ok = gpio:set_int(?DOWN_PIN, rising),
-    {ok, _} = gpio:start_link(?ONES_PIN, output),
-    {ok, _} = gpio:start_link(?TWOS_PIN, output),
+    {ok, _} = gpio:start_link({?ONES_PIN, output}),
+    {ok, _} = gpio:start_link({?TWOS_PIN, output}),
     {ok, #state{}}.
 
 handle_call(_Request, _From, State) ->


### PR DESCRIPTION
I made changes in examples according 369c5ff9db28bdbf2ea2bc3ec560542113ef1daf
