### PR TITLE
Enable Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: erlang
+
+otp_release:
+    - 17.4
+
+before_install:
+    - wget https://s3.amazonaws.com/rebar3/rebar3
+    - chmod +x rebar3
+
+script:
+    - ./rebar3 compile
+    - ./rebar3 dialyzer
+    - make -C examples

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Erlang/ALE -- Erlang Actor Library for Embedded
 
+[![Build Status](https://travis-ci.org/esl/erlang_ale.svg)](https://travis-ci.org/esl/erlang_ale)
+
 Erlang/ALE provides high level abstractions for interfacing to hardware
 peripherals through I2C, SPI, and GPIOs on embedded platforms.
 


### PR DESCRIPTION
Assuming that Travis CI is enabled for the esl/erlang_ale repository, this change should make everything work so that new pull requests can automatically be checked for compiler errors. 